### PR TITLE
FIX:Back configのproduction.rbにCSRFトークン検証時のOriginCheckをオフにする設定を追加

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -95,4 +95,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.action_controller.forgery_protection_origin_check = false
 end


### PR DESCRIPTION
## 概要
CSRFトークン検証時に出るActionController::InvalidAuthenticityTokenエラーを解消

## 原因
CSRFトークン検証時に、Token送信元のOriginと送信先のOriginが一致するかを検証するステップがDefaultで存在する。SPAとAPIでOriginを分離した設計なので、このステップを無効化する

## やったこと
- backend/config/environments/production.rbに以下のコードを追加
  - config.action_controller.forgery_protection_origin_check = false