### PR TITLE
FIX:Front タイマーの表示と消費カロリーの表示がずれているバグを修正

### DIFF
--- a/frontend/src/components/workout/WorkoutCount.jsx
+++ b/frontend/src/components/workout/WorkoutCount.jsx
@@ -39,11 +39,11 @@ function WorkoutCount(props) {
 
   useEffect(() => {
     if(totalSeconds === 0) return;
-    setBurnedCalorie(prevCalorie => new Big(workout.burnedKcalPerSec).plus(prevCalorie).toNumber())
-    setUnburnedCalorie(prevCalorie => prevCalorie - new Big(workout.burnedKcalPerSec))
+    const burnedCalorieVal = new Big(workout.burnedKcalPerSec).times(totalSeconds);
+    setBurnedCalorie(burnedCalorieVal.toNumber());
+    setUnburnedCalorie(new Big(intakedCalorie).minus(burnedCalorieVal).toNumber());
     setSavedMessage(null);
-    console.log(totalSeconds)
-  }, [totalSeconds, workout.burnedKcalPerSec])
+  }, [totalSeconds, workout.burnedKcalPerSec, intakedCalorie])
 
   //記録を保存処理
   const createWorkoutRecord = async() => {


### PR DESCRIPTION
## 概要
バグ修正

## バグ
- 内容
  - スリープ状態から復帰した時、タイマーに表示された時間に対して、消費カロリーの表示が少ない
- 原因
  - タイマーが進んだ際に発火するuseEffectコールバックの処理で、消費カロリーの値を1秒単位で変化させていたこと。
- 解決策
  - タイマーが進んだ際に発火するuseEffectコールバックの処理で、タイマーのtotalSecondsに対する消費カロリーを表示するように変更する
